### PR TITLE
Simplify plain project creation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ argocd account generate-token --account kruise-admin
 ```
 
 ## `kruise.yaml` 설정
-프로젝트 저장소 루트에 `kruise.yaml`(YAML)을 추가하면 Jenkins 파라미터와 병합하여 다음 작업에 사용합니다. `projectRepositoryUrl`은 Jenkins Job 필수 파라미터이며 `kruise.yaml`에는 포함하지 않습니다.
+프로젝트 저장소 루트에 `kruise.yaml`(YAML)을 추가하면 Jenkins 파라미터와 병합하여 다음 작업에 사용합니다. Jenkins Job에서는 저장소 URL과 크레덴셜 정도만 입력하고, 나머지 필드는 `kruise.yaml` 또는 기본값을 사용합니다. `projectRepositoryUrl`은 Jenkins Job 필수 파라미터이며 `kruise.yaml`에는 포함하지 않습니다.
 
 - **필수 키**: `projectName`, `projectRepositoryBranch`, `clusterName`, `imagePath`
 - **옵션 키 및 기본값**
   - `phase`: 빈 문자열
   - `helmChartName`: `kruise-standard-server`
-  - `helmChartValues`: Jenkins 파라미터 기본값(Helm values 문자열)
+  - `helmChartValues`: Jenkins 기본값(Helm values 문자열)
   - `override`: `false`
   - `proxy`, `noProxy`: 빈 문자열
-  - `projectRepositoryCredential`, `containerRegistryCredential`, `kruiseRepositoryCredential`, `kruiseRepositoryUrl`, `kruiseBranch`: Jenkins 파라미터 값 사용
+  - `kruiseRepositoryUrl`, `kruiseBranch`: Jenkins 파라미터 기본값 사용 가능
 
 예시(YAML):
 ```yaml

--- a/helm/jenkins/README.md
+++ b/helm/jenkins/README.md
@@ -40,7 +40,8 @@ kruise 소스를 다운 받을 계정의 token 을 credentials 로 생성해서 
  
 # kruise jobs
 ## `kruise.action.create-project-plain`
+- `projectRepositoryUrl` param: 프로젝트 git 주소.
 - `projectRepositoryCredential` param: 프로젝트 git 인증용 크레덴셜. github access token.
 - `containerRegistryCredential` param: container image 를 push 하기 위한 크레덴셜. kic access token.
-- `argocdCredential` param: argocd login 용 token.
+- `override` param: 이미 존재하는 Argo CD Application 덮어쓰기 여부.
 

--- a/initJobs/actionCreateProjectPlain.Jenkinsfile
+++ b/initJobs/actionCreateProjectPlain.Jenkinsfile
@@ -16,18 +16,27 @@ readinessProbe.path=/
 service.port=3000
 """
 
-final Map defaultConfig = [
-    projectName: params.projectName?.trim(),
+final Map configDefaults = [
+    projectRepositoryBranch: "develop",
+    phase: "",
+    helmChartName: "kruise-standard-server",
+    helmChartValues: defaultHelmChartValues,
+    override: false,
+    proxy: "",
+    noProxy: "",
+]
+
+final Map parameterOverrides = [
     projectRepositoryUrl: params.projectRepositoryUrl?.trim(),
-    projectRepositoryBranch: params.projectRepositoryBranch ?: "develop",
+    projectRepositoryBranch: params.projectRepositoryBranch?.trim(),
     clusterName: params.clusterName?.trim(),
-    phase: params.phase ?: "",
+    phase: params.phase?.trim(),
     imagePath: params.imagePath?.trim(),
-    helmChartName: params.helmChartName ?: "kruise-standard-server",
-    helmChartValues: params.helmChartValues ?: defaultHelmChartValues,
+    helmChartName: params.helmChartName?.trim(),
+    helmChartValues: params.helmChartValues,
     override: params.override,
-    proxy: params.proxy ?: "",
-    noProxy: params.noProxy ?: "",
+    proxy: params.proxy?.trim(),
+    noProxy: params.noProxy?.trim(),
     projectRepositoryCredential: params.projectRepositoryCredential,
     containerRegistryCredential: params.containerRegistryCredential,
     kruiseRepositoryCredential: params.kruiseRepositoryCredential,
@@ -37,6 +46,7 @@ final Map defaultConfig = [
 
 Map mergedConfig = [:]
 Map loadedConfig = [:]
+Map overrideConfig = [:]
 
 
 def loadKruiseConfig(String baseDir) {
@@ -70,6 +80,10 @@ def validateConfig(Map config) {
 
 println("[kruise] job parameters: ${params}")
 
+overrideConfig = parameterOverrides.findAll { entry ->
+    entry.value != null && (!(entry.value instanceof String) || entry.value.trim() != "")
+}
+
 podTemplate(
     inheritFrom: 'jenkins-agent-default',
     name: "jenkins-agent-default",
@@ -79,16 +93,20 @@ podTemplate(
     instanceCap: instanceCap, //최대 생성가능한 동일 스팩 팟 갯수.
 ) {
     node("jenkins-agent-default") {
+        final Map bootstrapConfig = configDefaults + overrideConfig
+        if (!bootstrapConfig.projectRepositoryUrl) {
+            error("[kruise] projectRepositoryUrl 은 필수값입니다. Jenkins 파라미터를 확인하세요.")
+        }
         stage("Checkout kruise") {
-            git(url: defaultConfig.kruiseRepositoryUrl, branch: defaultConfig.kruiseBranch, credentialsId: defaultConfig.kruiseRepositoryCredential)
+            git(url: bootstrapConfig.kruiseRepositoryUrl, branch: bootstrapConfig.kruiseBranch, credentialsId: bootstrapConfig.kruiseRepositoryCredential)
         }
         stage("Checkout project") {
             dir('project') {
-                git(url: defaultConfig.projectRepositoryUrl, branch: defaultConfig.projectRepositoryBranch, credentialsId: defaultConfig.projectRepositoryCredential)
+                git(url: bootstrapConfig.projectRepositoryUrl, branch: bootstrapConfig.projectRepositoryBranch, credentialsId: bootstrapConfig.projectRepositoryCredential)
                 loadedConfig = loadKruiseConfig('.')
             }
-            mergedConfig = defaultConfig + loadedConfig
-            mergedConfig.projectRepositoryUrl = defaultConfig.projectRepositoryUrl
+            mergedConfig = configDefaults + loadedConfig + overrideConfig
+            mergedConfig.projectRepositoryUrl = bootstrapConfig.projectRepositoryUrl
             validateConfig(mergedConfig)
 
             if (mergedConfig.projectName == "kruise") {
@@ -98,7 +116,7 @@ podTemplate(
             println("[kruise] merged configuration: ${mergedConfig}")
         }
         stage('Run seedJobDsl') {
-            jobDsl(sandbox: true, targets: 'seedJobs/plain/**_JobDsl.groovy')
+            jobDsl(sandbox: true, targets: 'seedJobs/plain/**_JobDsl.groovy', additionalParameters: mergedConfig)
         }
         stage("createArgocdApp") {
             final String fixedBranchName = mergedConfig.projectRepositoryBranch.replace("/", "-").toLowerCase()

--- a/initJobs/actionCreateProjectPlain_JobDsl.groovy
+++ b/initJobs/actionCreateProjectPlain_JobDsl.groovy
@@ -7,72 +7,13 @@ pipelineJob("kruise.action.create-project-plain") {
             description("project repository 인증용 계정 을 지정하세요.")
         }
         stringParam {
-            name("projectName")
-            description("생성 할 프로젝트 이름입니다. 다른 프로젝트와 이름이 겹치지 않게 주의해주세요. 덮어쓰기가 될 수 있습니다. ex: centerflow-op")
-            trim(true)
-        }
-        stringParam {
             name("projectRepositoryUrl")
             description("빌드를 수행할 소스의 git 주소입니다. ex: TODO")
             trim(true)
         }
-        stringParam {
-            name("projectRepositoryBranch")
-            defaultValue("develop")
-            description("빌드를 수행할 branch 입니다. 생성된 argocd application 이름에 branch 명이 포함됩니다.")
-            trim(true)
-        }
-        stringParam {
-            name("clusterName")
-            description("argocd application 을 배포할 클러스터 이름입니다. kruise-argocd 에 클러스터 등록할때 지정한 이름입니다. kruise-argocd 에서 사용가능한 클러스터 이름을 확인할 수 있습니다. ex: in-cluster")
-        }
-        stringParam {
-            name("phase")
-            description("argocd application, k8d resource name 의 뒤에 붙을 접미사. (optional) 같은 project 안에서 배포단위별로 추가적인 접미사를 지정할 수 있습니다. ex: dev, cbt, prod")
-        }
-        stringParam {
-            name("imagePath")
-            description("image push 할 주소 입니다. 프로토콜을 제외한 경로 입니다. ex: TODO")
-            trim(true)
-        }
-        choiceParam {
-            name("helmChartName")
-            choices(["kruise-standard-server"])
-            description("kruise 에 정의된 helm chart 중에 선택합니다.")
-        }
-        textParam {
-            name("helmChartValues")
-            description("위에서 선택한 helmChart 에서 변경할 values 를 지정합니다. 배포할 image 의 repository 와 tag 는 kruise 에서 관리합니다.")
-            defaultValue("""replicaCount=1
-ingress.enabled=true
-ingress.className=nginx
-ingress.hosts[0].host=
-ingress.hosts[0].paths[0].path=/
-ingress.hosts[0].paths[0].pathType=ImplementationSpecific
-ingress.tls[0].secretName=
-ingress.tls[0].hosts[0]=
-serviceMonitor.enabled=true
-serviceMonitor.labels.release=prometheus
-livenessProbe.path=/
-readinessProbe.path=/
-service.port=3000
-""")
-        }
         booleanParam {
             name("override")
             description("기존에 이미 같은 이름으로 argocd application 이 만들어져 있을때, 덮어쓸지 여부입니다. ")
-        }
-        stringParam {
-            name("proxy")
-            defaultValue("")
-            description("proxy 서버 주소입니다.")
-            trim(true)
-        }
-        stringParam {
-            name("noProxy")
-            defaultValue("")
-            description("proxy 서버를 사용하지 않을 주소(도메인, ip) 목록입니다. 여러개의 주소는 ','  로 구별합니다.")
-            trim(true)
         }
 
         credentialsParam("containerRegistryCredential") {


### PR DESCRIPTION
## Summary
- reduce the `kruise.action.create-project-plain` job parameters to the credentials and repository URL
- rely on `kruise.yaml`/built-in defaults inside the Jenkinsfile and pass merged config into seeded jobs
- document the leaner parameter expectations in the READMEs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69345034e6a883219caead244736fe6a)