### PR TITLE
Improve gradle init job config handling

### DIFF
--- a/initJobs/actionCreateProjectGradle.Jenkinsfile
+++ b/initJobs/actionCreateProjectGradle.Jenkinsfile
@@ -1,53 +1,106 @@
 final Integer idleMinutes = 480 //8시간
 final Integer instanceCap = 5
 
-final String projectName = params.projectName
-final String projectRepositoryUrl = params.projectRepositoryUrl
-final String projectRepositoryBranch = params.projectRepositoryBranch
-final String helmChartName = params.helmChartName
-final helmChartValues = params.helmChartValues
-final String imagePath = params.imagePath
+final String defaultHelmChartValues = """replicaCount=1
+ingress.enabled=true
+ingress.className=nginx
+ingress.hosts[0].host=
+ingress.hosts[0].paths[0].path=/
+ingress.hosts[0].paths[0].pathType=ImplementationSpecific
+ingress.tls[0].secretName=
+ingress.tls[0].hosts[0]=
+serviceMonitor.enabled=true
+serviceMonitor.labels.release=prometheus
+filebeat.enabled=true
+filebeat.logFilePath=/opt/app/logs
+filebeat.logFileName=
+filebeat.outputElasticsearchHost=
+containerEnv.SPRING_PROFILES_ACTIVE=dev"""
 
-final String clusterName = params.clusterName
-final String phase = params.phase
-final def override = params.override
+final Map configDefaults = [
+    projectRepositoryBranch: "develop",
+    phase: "",
+    helmChartName: "kruise-standard-server",
+    helmChartValues: defaultHelmChartValues,
+    override: false,
+    proxy: "",
+    noProxy: "",
+    jdkVersion: 21,
+    gradleBuildCommand: "build",
+]
 
-//아래 변수는 build job 생성용 DSL 에서 사용한다.(jenkins job 으로는 넘기지 않음)---
-final def kruiseRepositoryCredential = params.kruiseRepositoryCredential
-final String kruiseRepositoryUrl = params.kruiseRepositoryUrl
-final String kruiseBranch = params.kruiseBranch
-//------
+final Map parameterOverrides = [
+    projectName: params.projectName?.trim(),
+    projectRepositoryUrl: params.projectRepositoryUrl?.trim(),
+    projectRepositoryBranch: params.projectRepositoryBranch?.trim(),
+    clusterName: params.clusterName?.trim(),
+    phase: params.phase?.trim(),
+    imagePath: params.imagePath?.trim(),
+    helmChartName: params.helmChartName?.trim(),
+    helmChartValues: params.helmChartValues,
+    override: params.override,
+    proxy: params.proxy?.trim(),
+    noProxy: params.noProxy?.trim(),
+    projectRepositoryCredential: params.projectRepositoryCredential,
+    containerRegistryCredential: params.containerRegistryCredential,
+    kruiseRepositoryCredential: params.kruiseRepositoryCredential,
+    kruiseRepositoryUrl: params.kruiseRepositoryUrl,
+    kruiseBranch: params.kruiseBranch,
+    jdkVersion: params.jdkVersion,
+    gradleBuildCommand: params.gradleBuildCommand,
+]
 
-final String fixedBranchName = projectRepositoryBranch.replace("/", "-").toLowerCase()
-final String fixedPhase = phase == "" ? "" : "-${phase}"
-final def releaseName = "${projectName}${fixedPhase}"
-final def argocdApplicationName = "${releaseName}-${clusterName}-${fixedBranchName}"
+Map mergedConfig = [:]
+Map loadedConfig = [:]
+Map overrideConfig = [:]
+boolean configFileExists = false
+
+
+def loadKruiseConfig(String baseDir) {
+    def configFile = "${baseDir}/kruise.yaml"
+    if (!fileExists(configFile)) {
+        println("[kruise] kruise.yaml not found. Using Jenkins parameters and defaults.")
+        return [:]
+    }
+
+    try {
+        def parsed = readYaml(file: configFile)
+        if (parsed == null) {
+            error("[kruise] kruise.yaml is empty. Please provide required keys.")
+        }
+        println("[kruise] Loaded kruise.yaml: ${parsed}")
+        return parsed as Map
+    } catch (Exception e) {
+        error("[kruise] Failed to parse kruise.yaml. ${e.message}")
+    }
+}
+
+def validateConfig(Map config, Map requirements, String contextLabel) {
+    List<String> invalidKeys = []
+
+    requirements.requiredKeys.each { key ->
+        def value = config[key]
+        if (value == null || (value instanceof String && value.trim() == "")) {
+            invalidKeys << "${key}(required)"
+        }
+    }
+
+    requirements.expectedTypes.each { key, expectedType ->
+        def value = config[key]
+        if (value != null && !(value instanceof expectedType)) {
+            invalidKeys << "${key}(expected ${expectedType.simpleName})"
+        }
+    }
+
+    if (!invalidKeys.isEmpty()) {
+        error("[kruise] ${contextLabel} 설정 오류가 있습니다. 문제 키: ${invalidKeys.join(', ')}")
+    }
+}
 
 println("[kruise] job parameters: ${params}")
 
-//validation ----
-if (projectName == "") {
-    error("[kruise] projectName 은 필수값입니다.")
-}
-
-if (projectName == "kruise") {
-    error("[kruise] 허용되지 않는 projectName 입니다. projectName: ${projectName}")
-}
-
-if (clusterName == "") {
-    error("[kruise] clusterName 은 필수값입니다.")
-}
-
-if (projectRepositoryUrl == "") {
-    error("[kruise] projectRepositoryUrl 은 필수값입니다.")
-}
-
-if (projectRepositoryBranch == "") {
-    error("[kruise] projectRepositoryBranch 은 필수값입니다.")
-}
-
-if (imagePath == "") {
-    error("[kruise] imagePath 은 필수값입니다.")
+overrideConfig = parameterOverrides.findAll { entry ->
+    entry.value != null && (!(entry.value instanceof String) || entry.value.trim() != "")
 }
 
 podTemplate(
@@ -59,25 +112,177 @@ podTemplate(
     instanceCap: instanceCap, //최대 생성가능한 동일 스팩 팟 갯수.
 ) {
     node("jenkins-agent-default") {
+        final Map bootstrapConfig = configDefaults + overrideConfig
+        if (!bootstrapConfig.projectRepositoryUrl) {
+            error("[kruise] projectRepositoryUrl 은 필수값입니다. Jenkins 파라미터를 확인하세요.")
+        }
+        validateConfig(
+            bootstrapConfig,
+            [
+                requiredKeys: [
+                    "projectRepositoryUrl",
+                    "projectRepositoryBranch",
+                    "kruiseRepositoryUrl",
+                    "kruiseBranch",
+                    "projectRepositoryCredential",
+                    "kruiseRepositoryCredential",
+                ],
+                expectedTypes: [
+                    projectRepositoryUrl: String,
+                    projectRepositoryBranch: String,
+                    projectRepositoryCredential: String,
+                    kruiseRepositoryCredential: String,
+                    kruiseRepositoryUrl: String,
+                    kruiseBranch: String,
+                ],
+            ],
+            "Checkout stage"
+        )
         stage("Checkout kruise") {
-          git(url: kruiseRepositoryUrl, branch: kruiseBranch, credentialsId: kruiseRepositoryCredential)
+            git(url: bootstrapConfig.kruiseRepositoryUrl, branch: bootstrapConfig.kruiseBranch, credentialsId: bootstrapConfig.kruiseRepositoryCredential)
+        }
+        stage("Checkout project") {
+            dir('project') {
+                git(url: bootstrapConfig.projectRepositoryUrl, branch: bootstrapConfig.projectRepositoryBranch, credentialsId: bootstrapConfig.projectRepositoryCredential)
+                loadedConfig = loadKruiseConfig('.')
+                configFileExists = !loadedConfig.isEmpty()
+            }
+            if (configFileExists) {
+                mergedConfig = configDefaults + loadedConfig + overrideConfig
+            } else {
+                mergedConfig = configDefaults + overrideConfig
+            }
+            mergedConfig.projectRepositoryUrl = bootstrapConfig.projectRepositoryUrl
+            mergedConfig.projectRepositoryCredential = bootstrapConfig.projectRepositoryCredential
+            mergedConfig.containerRegistryCredential = bootstrapConfig.containerRegistryCredential
+            mergedConfig.kruiseRepositoryUrl = bootstrapConfig.kruiseRepositoryUrl
+            mergedConfig.kruiseRepositoryCredential = bootstrapConfig.kruiseRepositoryCredential
+            mergedConfig.kruiseBranch = bootstrapConfig.kruiseBranch
+
+            validateConfig(
+                mergedConfig,
+                [
+                    requiredKeys: [
+                        "projectName",
+                        "projectRepositoryUrl",
+                        "projectRepositoryBranch",
+                        "clusterName",
+                        "imagePath",
+                        "jdkVersion",
+                        "gradleBuildCommand",
+                    ],
+                    expectedTypes: [
+                        projectName: String,
+                        projectRepositoryUrl: String,
+                        projectRepositoryBranch: String,
+                        clusterName: String,
+                        imagePath: String,
+                        helmChartName: String,
+                        helmChartValues: Object,
+                        phase: String,
+                        override: Boolean,
+                        proxy: String,
+                        noProxy: String,
+                        jdkVersion: Object,
+                        gradleBuildCommand: Object,
+                    ],
+                ],
+                configFileExists ? "kruise.yaml" : "Jenkins 파라미터"
+            )
+
+            if (mergedConfig.projectName == "kruise") {
+                error("[kruise] 허용되지 않는 projectName 입니다. projectName: ${mergedConfig.projectName}")
+            }
+
+            final String fixedBranchName = mergedConfig.projectRepositoryBranch.replace("/", "-").toLowerCase()
+            final String fixedPhase = mergedConfig.phase == "" ? "" : "-${mergedConfig.phase}"
+            mergedConfig.releaseName = "${mergedConfig.projectName}${fixedPhase}"
+            mergedConfig.argocdApplicationName = "${mergedConfig.releaseName}-${mergedConfig.clusterName}-${fixedBranchName}"
+
+            println("[kruise] merged configuration: ${mergedConfig}")
         }
         stage('Run seedJobDsl') {
-            jobDsl(sandbox: true, targets: 'seedJobs/gradle/**_JobDsl.groovy')
+            validateConfig(
+                mergedConfig,
+                [
+                    requiredKeys: [
+                        "projectName",
+                        "projectRepositoryUrl",
+                        "projectRepositoryBranch",
+                        "clusterName",
+                        "imagePath",
+                        "jdkVersion",
+                        "gradleBuildCommand",
+                    ],
+                    expectedTypes: [
+                        projectName: String,
+                        projectRepositoryUrl: String,
+                        projectRepositoryBranch: String,
+                        clusterName: String,
+                        imagePath: String,
+                        helmChartName: String,
+                        helmChartValues: Object,
+                        phase: String,
+                        override: Boolean,
+                        proxy: String,
+                        noProxy: String,
+                        jdkVersion: Object,
+                        gradleBuildCommand: Object,
+                    ],
+                ],
+                'Run seedJobDsl'
+            )
+            jobDsl(
+                sandbox: true,
+                targets: 'seedJobs/gradle/**_JobDsl.groovy',
+                additionalParameters: mergedConfig
+            )
         }
         stage("createArgocdApp") {
+            validateConfig(
+                mergedConfig,
+                [
+                    requiredKeys: [
+                        "projectName",
+                        "projectRepositoryUrl",
+                        "projectRepositoryBranch",
+                        "clusterName",
+                        "imagePath",
+                        "helmChartName",
+                        "helmChartValues",
+                        "jdkVersion",
+                        "gradleBuildCommand",
+                    ],
+                    expectedTypes: [
+                        projectName: String,
+                        projectRepositoryUrl: String,
+                        projectRepositoryBranch: String,
+                        clusterName: String,
+                        imagePath: String,
+                        helmChartName: String,
+                        helmChartValues: Object,
+                        phase: String,
+                        override: Boolean,
+                        proxy: String,
+                        noProxy: String,
+                        jdkVersion: Object,
+                        gradleBuildCommand: Object,
+                    ],
+                ],
+                'createArgocdApp'
+            )
             build(
                 job: "kruise.managed.create-argocd-app",
                 wait: true,
                 parameters: [
-                    string(name: "clusterName", value: clusterName),
-                    string(name: "releaseName", value: releaseName),
-                    string(name: "argocdProjectName", value: projectName),
-                    string(name: "argocdApplicationName", value: argocdApplicationName),
-                    string(name: "helmChartName", value: helmChartName),
-                    text(name: "helmChartValues", value: helmChartValues),
-                    string(name: "imagePath", value: imagePath),
-                    booleanParam(name: "override", value: override),
+                    string(name: "clusterName", value: mergedConfig.clusterName),
+                    string(name: "releaseName", value: mergedConfig.releaseName),
+                    string(name: "argocdProjectName", value: mergedConfig.projectName),
+                    string(name: "argocdApplicationName", value: mergedConfig.argocdApplicationName),
+                    string(name: "helmChartName", value: mergedConfig.helmChartName),
+                    text(name: "helmChartValues", value: mergedConfig.helmChartValues?.toString()),
+                    string(name: "imagePath", value: mergedConfig.imagePath),
+                    booleanParam(name: "override", value: mergedConfig.override),
                 ]
             )
         }

--- a/kruise.yaml
+++ b/kruise.yaml
@@ -1,0 +1,35 @@
+replicaCount: 1
+image:
+  repository: example.com/kruise-standard-server
+  tag: "1.0.0"
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: example-tls
+      hosts:
+        - example.local
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus
+livenessProbe:
+  path: /
+  port: http
+readinessProbe:
+  path: /
+  port: http
+service:
+  port: 3000
+containerEnv:
+  SPRING_PROFILES_ACTIVE: dev
+filebeat:
+  enabled: true
+  logFilePath: /opt/app/logs
+  logFileName: application.log
+  outputElasticsearchHost: logging.example.com:9200


### PR DESCRIPTION
## Summary
- add a sample kruise.yaml Helm values file for rendering the standard server chart
- load and validate kruise.yaml in the gradle init job, merging defaults and Jenkins parameters
- pass merged configuration to seed DSL and create-argocd-app steps to keep behavior consistent with kruise.yaml

## Testing
- bash -n sh/argocd-add-cluster.sh
- bash -n sh/helm.sh
- helm template charts/kruise-standard-server -f kruise.yaml *(fails: helm CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693457f7d6d48321b5c1d2971ec25fb9)